### PR TITLE
RF: install dcm2niix and heudiconv from neurodebian

### DIFF
--- a/generate_container.sh
+++ b/generate_container.sh
@@ -12,12 +12,11 @@ generate() {
               git-annex-standalone python-nipype virtualenv \
               python-dcmstack python-configparser python-funcsigs \
               python-pytest dcmtk python-pip python-wheel python-setuptools python-datalad \
+              heudiconv dcm2niix \
     --run "curl -sL https://deb.nodesource.com/setup_6.x | bash - "\
     --install nodejs npm \
     --run "npm install -g bids-validator@1.1.1" \
     --run "mkdir /afs /inbox" \
-    --run "pip install heudiconv" \
-    --dcm2niix version="v1.0.20181125" method="source" \
     --run "echo '#!/bin/bash' >> /neurodocker/heudiconv.sh && echo 'heudiconv \"\$@\"' >> /neurodocker/heudiconv.sh && chmod +x /neurodocker/heudiconv.sh" \
     --user=reproin \
     --entrypoint "/neurodocker/heudiconv.sh"


### PR DESCRIPTION
Especially now since we use nd_freeze, best to rely on APT repositories
where possible.  But also better to use dcm2niix build which is known to
pass dcm2niix test_qa (as we have it in neurodebian

@mvdoc - do you remember why you built dcm2niix from source and installed from pip -- that we were lagging with releases/packaging or there was more to it?