### PR TITLE
WiP ENH: bin/reproin - script to assist using heudiconv etc in a prototypical setup

### DIFF
--- a/bin/reproin
+++ b/bin/reproin
@@ -196,7 +196,7 @@ study-show|study-convert)
 		esac
 	done
 	if [ "$action" = "study-convert" ]; then
-		"$self" "validator-summary" "$study"
+		"$self" "validator-summary" "$study" || echo "WARNING: Failed to provide validator summary: $?"
 	fi
 
 	;;

--- a/bin/reproin
+++ b/bin/reproin
@@ -10,7 +10,7 @@ set -eu
 #
 # A Master run script for a study
 #
-dcm2niix_version=$(dcm2niix -v|grep '^v')
+dcm2niix_version=$(dcm2niix -v|grep '^v' || dcm2niix -v|sed -n -e '/dcm2niiX version v/s,.*X version ,,gp'| sed -e 's,[ \t].*,,g')
 if [ "$#" = 0 ]; then
 	echo -n "heudiconv: "
 	heudiconv --version
@@ -29,7 +29,7 @@ skipfile=".heudiconv/sid-skip" # TODO: check what used now
 vallog=".heudiconv/bids-validator.log"
 valconfig=".bids-validator-config.json"
 # common prefix for heudiconv invocation
-heudiconvcmd="/usr/bin/heudiconv -c dcm2niix --bids -o $bidsdir -g accession_number"
+heudiconvcmd="heudiconv -c dcm2niix --bids -o $bidsdir -g accession_number"
 
 self=$(realpath "$0")
 action="$1"
@@ -44,10 +44,11 @@ if [ "$action" = "lists-update" ]; then
 fi
 
 # The rest of the commands operate on a given study
-study="$2"
+study=${2#*:}
 
-# TODO: Add option to remap
-ostudy=$study; 
+# TODO: Add option to remap -- record those remappings somehow!
+# For now allowing for ostudy:study mapping in cmdline
+ostudy="${2%%:*}"
 # TODO: Add option to limit by year/month
 # TODO: Add option to "hardcode" add session
 		
@@ -108,10 +109,19 @@ study-show|study-convert)
 	# to not do
 
 	# Check that version of the dcm2niix is the same
-	dcm2niix_study=$(git grep -h ConversionSoftwareVersion | awk '{print $2;}' | sed -e 's,[",],,g' | sort | uniq)
+	dcm2niixs_study=( $(git grep -h ConversionSoftwareVersion | awk '{print $2;}' | sed -e 's,[",],,g' | sort | uniq) )
+	if [[ ${#dcm2niixs_study[@]} != 1 ]]; then
+		echo "W: Study already used multiple versions of dcm2niix: ${dcm2niixs_study[@]}"
+	fi
+	dcm2niix_study=${dcm2niixs_study[-1]}
 	if [ ! -z "$dcm2niix_study" ] && [ "$dcm2niix_study" != "$dcm2niix_version" ]; then
-		echo "E: Wrong environment - dcm2niix $dcm2niix_version when study used $dcm2niix_study"
-		exit 1
+		msg="Wrong environment - dcm2niix $dcm2niix_version when study used $dcm2niix_study"
+		case "$action" in
+		study-convert)
+			echo "E: $msg" >&2
+			exit 1
+		esac
+		echo "W: $msg"
 	fi
 
 
@@ -147,13 +157,13 @@ study-show|study-convert)
 			exit 1
 		fi
 		if [ -n "$targetsub" ] && [ "$sub" != "$targetsub" ]; then
-			echo "Skipping subject $sub"
+			echo "Skipping subject $sub since != $targetsub"
 			continue
 		fi
 		#echo "Subject: $sub  Session: $ses"
 		subsesheudiconvdir=$heudiconvdir/$sub
 		if [ ! -z "$ses" ]; then
-			subsesheudiconvdir+=/$ses
+			subsesheudiconvdir+=/ses-$ses
 		fi
 		if grep -q -R $td $heudiconvdir/* 2>/dev/null; then
 			echo "$td done  # $subses"
@@ -169,7 +179,12 @@ study-show|study-convert)
 			echo "Converting subject $sub for session $ses ($studydir)"
 			mkdir -p "$subsesheudiconvdir"
 			logfile="$subsesheudiconvdir/heudiconv.log"
-			eval "$cmd" > "$logfile" 2>&1
+			if ! eval "$cmd" > "$logfile" 2>&1; then
+				echo "E: conversion script exited with $?. Please check details in $studydir/$logfile."
+			        echo "   The tail of it is:"
+				tail "$logfile"
+				exit 1
+			fi
 
 			echo "Runing validator now"
 			"$self" "validator-save" "$study" || "echo validator failed; check $vallog"

--- a/bin/reproin
+++ b/bin/reproin
@@ -19,16 +19,37 @@ if [ "$#" = 0 ]; then
 	exit 0
 fi
 
-study="$1"
-action="$2"
+dicomdir="/inbox/DICOM"
+bidsdir="/inbox/BIDS"
+listdir="$HOME/reproin-lists"
+
+heuristic="reproin"
+
+heudiconvdir=".heudiconv"
+skipfile=".heudiconv/sid-skip" # TODO: check what used now
+vallog=".heudiconv/bids-validator.log"
+valconfig=".bids-validator-config.json"
+# common prefix for heudiconv invocation
+heudiconvcmd="/usr/bin/heudiconv -c dcm2niix --bids -o $bidsdir -g accession_number"
+
+action="$1"
+# early
+if [ "$action" = "lists-update" ]; then
+	# TODO: get Y and M as args
+	Y=${2:-`date +%Y`}; 
+	M=${3:-`date +%m`}; 
+        eval "$heudiconvcmd -f $heuristic --command ls --files $dicomdir/$Y/$M/*/*/001*" >| $listdir/$Y${M}xx.txt
+	exit 0
+fi
+
+# The rest of the commands operate on a given study
+study="$2"
 
 # TODO: Add option to remap
 ostudy=$study; 
 # TODO: Add option to limit by year/month
 # TODO: Add option to "hardcode" add session
 		
-
-bidsdir="/inbox/BIDS"
 studydir="$bidsdir/$study"
 
 if [ ! -e "$studydir" ]; then
@@ -37,22 +58,37 @@ if [ ! -e "$studydir" ]; then
 else
 	cd "$studydir"  # implies it exists!!! TODO
 fi
-heudiconvdir=".heudiconv"
-skipfile=".heudiconv/sid-skip" # TODO: check what used now
-vallog=".heudiconv/bids-validator.log"
-valconfig=".bids-validator-config.json"
+
 if [ ! -e "$valconfig" ]; then
 	valconfig=~/heudiconv/heudiconv/heuristics/reproin_validator.cfg
 fi
 
+# Track already seen
+subses_ids=""
 
 case "$action" in
-create)
-	echo "not implemented"
-	exit 1
+study-create)
+	if [ -e "$studydir" ]; then
+		echo "$study already exists, nothing todo"
+		exit 1;
+	fi
+	cd "$bidsdir"
+	echo "$study" | tr '/' '\n' \
+	| while read d; do
+		if [ ! -e "$d" ] ; then
+			if [ "$PWD/$d" == "$studydir" ]; then
+				datalad create --fake-dates -d . "$d"
+			else
+				datalad create -d . "$d"
+			fi
+		fi
+		cd "$d"
+	done
+	cd "$studydir"
+	datalad run-procedure cfg_reproin_bids
+	git tag -m "The beginning" 0.0.0
 	# after creating a dataset tag it with 0.0.0
 	# This would allow for a sensible git describe output
-	git tag -m "The beginning" 0.0.0
 	;;
 accession-skip)
 	echo "not implemented"
@@ -63,28 +99,33 @@ accession-skip)
 	git annex add "$skipfile"
 	git commit -m 'skip an accession' "$skipfile"
 	;;
-echo|eval)
+study-show|study-convert)
 	# TODO: make it do a pass and verify that no duplicate/existing session+subject in
 	# what to be converted.  We might need to remove some older one or mark some as
 	# to not do
 	targetsub="${3:-}"
-	heuristic="reproin"
 	if [ -e "$heudiconvdir/heuristic.py" ]; then
 		echo "Will use study specific heuristic"
 		heuristic=".heudiconv/heuristic.py"
 	fi
 
 	# TODO: use datalad run/containers-run
-	grep -h -B1 "$ostudy'" ~/heudiconv-*txt  \
+	grep -h -B1 "$ostudy'" $listdir/*xx.txt  \
 	| grep 'DICOM.*/\(qa\|A\)' \
 	| sort \
 	| uniq \
 	| while read d; do 
 		td=${d//\/001*/};  
 		# TODO: too ad-hoc, do properly
-		subses=$(grep -h -A1 $td ~/heudiconv-*txt | awk '/StudySess/{print $2, $3}' | uniq); 
+		subses=$(grep -h -A1 $td $listdir/*xx.txt | awk '/StudySess/{print $2, $3}' | uniq); 
 		sub=$(echo "$subses" | sed -e "s,.*subject=',,g" -e "s,'),,g")
 		ses=$(echo "$subses" | sed -e "s,.*session='*,,g" -e "s/'*, .*//g" -e "s,None,,g")
+		subses_id="sub=$sub:ses=$ses"
+		if [[ " $subses_ids " =~ " ${subses_id} " ]]; then
+			echo "WARNING: $subses_id already known"
+		else
+			subses_ids+=" $subses_id"
+		fi
 		if [ -z "$sub" ]; then
 			echo "ERROR: Empty subject for $d"
 			exit 1
@@ -104,12 +145,12 @@ echo|eval)
 			continue
 		fi
 		
-		cmd="/usr/bin/heudiconv -c dcm2niix -o $bidsdir --bids -l $study -f $heuristic -g accession_number --files  $td"
+		cmd="$heudiconvcmd -f $heuristic -l $study --files $td"
 		case "$action" in
-		echo)
+		study-show)
 			echo "$cmd # subject=$sub session=$ses"
 			;;
-		eval)
+		study-convert)
 			echo "Converting subject $sub for session $ses ($studydir)"
 			mkdir -p "$subsesheudiconvdir"
 			logfile="$subsesheudiconvdir/heudiconv.log"
@@ -118,16 +159,16 @@ echo|eval)
 			echo "Runing validator now"
 			( 
 				builtin cd -
-				"$0" "$study" "validator"  || "echo validator failed; check $valfile"
+				"$0" "validator-save" "$study" || "echo validator failed; check $vallog"
 			)
 			if [ -e "$vallog" ]; then
                            cp --reflink=auto "$vallog" "$subsesheudiconvdir/bids-validator.log"
 			fi
-			datalad save -d . -m "Converted subject $sub session $ses" . .heudiconv
+			datalad save -m "Converted subject $sub session $ses" . .heudiconv
 			;;
 		esac
 	done
-	if [ "$action" = "eval" ]; then
+	if [ "$action" = "study-convert" ]; then
 		echo "Errors/warnings from current state of the validator:"
 		grep -E '^\s*[0-9]+: \[' "$vallog"
 	fi
@@ -141,7 +182,7 @@ validator-save)
 	vallog_="$PWD/$vallog"
 	(
 		builtin cd -
-		"$0" "$study" "validator" > "$vallog_"
+		"$0" "validator" "$study" > "$vallog_"
 	)
 	echo "Validator output in $vallog_"
 	datalad save -d . -m "New BIDS validator output" $vallog

--- a/bin/reproin
+++ b/bin/reproin
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# A helper to assist using heudiconv with reproin heuristic in a (proto)typical
+# setup.
+#
+# ATM paths and setup is DBIC specific. TODO - make it use a config file
+#
+set -eu
+
+#
+# A Master run script for a study
+#
+
+if [ "$#" = 0 ]; then
+	echo -n "heudiconv: "
+	heudiconv --version
+	echo -n "dcm2niix: "
+	dcm2niix -v
+	exit 0
+fi
+
+study="$1"
+action="$2"
+
+# TODO: Add option to remap
+ostudy=$study; 
+# TODO: Add option to limit by year/month
+# TODO: Add option to "hardcode" add session
+		
+
+bidsdir="/inbox/BIDS"
+studydir="$bidsdir/$study"
+
+if [ ! -e "$studydir" ]; then
+	echo "I: no study directory yet - $studydir"
+	cd /tmp  # to be safe/avoid side-effects
+else
+	cd "$studydir"  # implies it exists!!! TODO
+fi
+heudiconvdir=".heudiconv"
+skipfile=".heudiconv/sid-skip" # TODO: check what used now
+vallog=".heudiconv/bids-validator.log"
+valconfig=".bids-validator-config.json"
+if [ ! -e "$valconfig" ]; then
+	valconfig=~/heudiconv/heudiconv/heuristics/reproin_validator.cfg
+fi
+
+
+case "$action" in
+create)
+	echo "not implemented"
+	exit 1
+	# after creating a dataset tag it with 0.0.0
+	# This would allow for a sensible git describe output
+	git tag -m "The beginning" 0.0.0
+	;;
+accession-skip)
+	echo "not implemented"
+	exit 1
+	# TODO: mark provided "$3" accession as one to skip
+	git annex unlock "$skipfile"
+	echo "$3 ${4:-}" > "$skipfile"
+	git annex add "$skipfile"
+	git commit -m 'skip an accession' "$skipfile"
+	;;
+echo|eval)
+	# TODO: make it do a pass and verify that no duplicate/existing session+subject in
+	# what to be converted.  We might need to remove some older one or mark some as
+	# to not do
+	targetsub="${3:-}"
+	heuristic="reproin"
+	if [ -e "$heudiconvdir/heuristic.py" ]; then
+		echo "Will use study specific heuristic"
+		heuristic=".heudiconv/heuristic.py"
+	fi
+
+	# TODO: use datalad run/containers-run
+	grep -h -B1 "$ostudy'" ~/heudiconv-*txt  \
+	| grep 'DICOM.*/\(qa\|A\)' \
+	| sort \
+	| uniq \
+	| while read d; do 
+		td=${d//\/001*/};  
+		# TODO: too ad-hoc, do properly
+		subses=$(grep -h -A1 $td ~/heudiconv-*txt | awk '/StudySess/{print $2, $3}' | uniq); 
+		sub=$(echo "$subses" | sed -e "s,.*subject=',,g" -e "s,'),,g")
+		ses=$(echo "$subses" | sed -e "s,.*session='*,,g" -e "s/'*, .*//g" -e "s,None,,g")
+		if [ -z "$sub" ]; then
+			echo "ERROR: Empty subject for $d"
+			exit 1
+		fi
+		if [ -n "$targetsub" ] && [ "$sub" != "$targetsub" ]; then
+			echo "Skipping subject $sub"
+			continue
+		fi
+		#echo "Subject: $sub  Session: $ses"
+		subsesheudiconvdir=$heudiconvdir/$sub
+		if [ ! -z "$ses" ]; then
+			subsesheudiconvdir+=/$ses
+		fi
+		mkdir -p "$subsesheudiconvdir"
+		if grep -q -R $td $heudiconvdir/* 2>/dev/null; then
+			echo "$td done  # $subses"
+			continue
+		fi
+		
+		cmd="/usr/bin/heudiconv -c dcm2niix -o $bidsdir --bids -l $study -f $heuristic -g accession_number --files  $td"
+		case "$action" in
+		echo)
+			echo "$cmd # subject=$sub session=$ses"
+			;;
+		eval)
+			echo "Converting subject $sub for session $ses ($studydir)"
+			mkdir -p "$subsesheudiconvdir"
+			logfile="$subsesheudiconvdir/heudiconv.log"
+			eval "$cmd" > "$logfile" 2>&1
+
+			echo "Runing validator now"
+			( 
+				builtin cd -
+				"$0" "$study" "validator"  || "echo validator failed; check $valfile"
+			)
+			if [ -e "$vallog" ]; then
+                           cp --reflink=auto "$vallog" "$subsesheudiconvdir/bids-validator.log"
+			fi
+			datalad save -d . -m "Converted subject $sub session $ses" . .heudiconv
+			;;
+		esac
+	done
+	if [ "$action" = "eval" ]; then
+		echo "Errors/warnings from current state of the validator:"
+		grep -E '^\s*[0-9]+: \[' "$vallog"
+	fi
+
+	;;
+validator)
+	bids-validator --verbose -c "$valconfig" $PWD
+	;;
+validator-save)
+	rm -f "$vallog"
+	vallog_="$PWD/$vallog"
+	(
+		builtin cd -
+		"$0" "$study" "validator" > "$vallog_"
+	)
+	echo "Validator output in $vallog_"
+	datalad save -d . -m "New BIDS validator output" $vallog
+	;;
+validator-show)
+	${PAGER:-vim} $vallog
+	;;
+*)
+	echo "Unknown action $action" >&2
+	exit 1
+	;;
+esac

--- a/bin/reproin
+++ b/bin/reproin
@@ -10,18 +10,17 @@ set -eu
 #
 # A Master run script for a study
 #
-
+dcm2niix_version=$(dcm2niix -v|grep '^v')
 if [ "$#" = 0 ]; then
 	echo -n "heudiconv: "
 	heudiconv --version
-	echo -n "dcm2niix: "
-	dcm2niix -v
+	echo "dcm2niix: $dcm2niix_version"
 	exit 0
 fi
 
 dicomdir="/inbox/DICOM"
 bidsdir="/inbox/BIDS"
-listdir="$HOME/reproin-lists"
+listdir="$bidsdir/reproin/lists"
 
 heuristic="reproin"
 
@@ -32,7 +31,9 @@ valconfig=".bids-validator-config.json"
 # common prefix for heudiconv invocation
 heudiconvcmd="/usr/bin/heudiconv -c dcm2niix --bids -o $bidsdir -g accession_number"
 
+self=$(realpath "$0")
 action="$1"
+
 # early
 if [ "$action" = "lists-update" ]; then
 	# TODO: get Y and M as args
@@ -90,19 +91,30 @@ study-create)
 	# after creating a dataset tag it with 0.0.0
 	# This would allow for a sensible git describe output
 	;;
-accession-skip)
-	echo "not implemented"
-	exit 1
-	# TODO: mark provided "$3" accession as one to skip
-	git annex unlock "$skipfile"
-	echo "$3 ${4:-}" > "$skipfile"
+study-accession-skip)
+	if [ -L "$skipfile" ]; then
+		(
+		cd "$(dirname $skipfile)"
+		git annex unlock "$(basename $skipfile)"
+		)
+	fi
+	echo "$3 ${4:-}" >> "$skipfile"
 	git annex add "$skipfile"
-	git commit -m 'skip an accession' "$skipfile"
+	datalad save -d. -m 'skip an accession' "$skipfile"
 	;;
 study-show|study-convert)
 	# TODO: make it do a pass and verify that no duplicate/existing session+subject in
 	# what to be converted.  We might need to remove some older one or mark some as
 	# to not do
+
+	# Check that version of the dcm2niix is the same
+	dcm2niix_study=$(git grep -h ConversionSoftwareVersion | awk '{print $2;}' | sed -e 's,[",],,g' | sort | uniq)
+	if [ ! -z "$dcm2niix_study" ] && [ "$dcm2niix_study" != "$dcm2niix_version" ]; then
+		echo "E: Wrong environment - dcm2niix $dcm2niix_version when study used $dcm2niix_study"
+		exit 1
+	fi
+
+
 	targetsub="${3:-}"
 	if [ -e "$heudiconvdir/heuristic.py" ]; then
 		echo "Will use study specific heuristic"
@@ -121,6 +133,10 @@ study-show|study-convert)
 		sub=$(echo "$subses" | sed -e "s,.*subject=',,g" -e "s,'),,g")
 		ses=$(echo "$subses" | sed -e "s,.*session='*,,g" -e "s/'*, .*//g" -e "s,None,,g")
 		subses_id="sub=$sub:ses=$ses"
+		if grep -q -R $td "$skipfile" 2>/dev/null; then
+			echo "$td skip  # $subses"
+			continue
+		fi
 		if [[ " $subses_ids " =~ " ${subses_id} " ]]; then
 			echo "WARNING: $subses_id already known"
 		else
@@ -139,7 +155,6 @@ study-show|study-convert)
 		if [ ! -z "$ses" ]; then
 			subsesheudiconvdir+=/$ses
 		fi
-		mkdir -p "$subsesheudiconvdir"
 		if grep -q -R $td $heudiconvdir/* 2>/dev/null; then
 			echo "$td done  # $subses"
 			continue
@@ -157,35 +172,31 @@ study-show|study-convert)
 			eval "$cmd" > "$logfile" 2>&1
 
 			echo "Runing validator now"
-			( 
-				builtin cd -
-				"$0" "validator-save" "$study" || "echo validator failed; check $vallog"
-			)
+			"$self" "validator-save" "$study" || "echo validator failed; check $vallog"
 			if [ -e "$vallog" ]; then
                            cp --reflink=auto "$vallog" "$subsesheudiconvdir/bids-validator.log"
 			fi
-			datalad save -m "Converted subject $sub session $ses" . .heudiconv
+			datalad save -m "Converted subject $sub session $ses" -r . .heudiconv .heudiconv/*
 			;;
 		esac
 	done
 	if [ "$action" = "study-convert" ]; then
-		echo "Errors/warnings from current state of the validator:"
-		grep -E '^\s*[0-9]+: \[' "$vallog"
+		"$self" "validator-summary" "$study"
 	fi
 
 	;;
 validator)
-	bids-validator --verbose -c "$valconfig" $PWD
+	bids-validator --verbose -c "$valconfig" $PWD || echo "WARNING: validator exited with exit code $?"
 	;;
 validator-save)
 	rm -f "$vallog"
-	vallog_="$PWD/$vallog"
-	(
-		builtin cd -
-		"$0" "validator" "$study" > "$vallog_"
-	)
-	echo "Validator output in $vallog_"
+	"$self" "validator" "$study" > "$vallog"
+	echo "Validator output in $PWD/$vallog"
 	datalad save -d . -m "New BIDS validator output" $vallog
+	;;
+validator-summary)
+	echo "Errors/warnings from current state of the validator:"
+	grep -E '^\s*[0-9]+: \[' "$vallog"
 	;;
 validator-show)
 	${PAGER:-vim} $vallog


### PR DESCRIPTION
Eventually it should be redone/RFed into a more generic helper.  ATM it encapsulates most of the typical steps done at DBIC to convert incoming DICOMs to BIDS datasets.

TODOs
- [ ] proper command line options handling. ATM just ad-hoc bash access to `$[0-9]`; and `--help`
- [ ] provide facility to use optionally present "mapping table" to inform about sessions whenever session annotation was not properly done in sequence names
- [ ] `reconvert [subjects]` - to reconvert previously converted data
- [ ] `study-injest-data` - HIRNI like mode of operation when DICOMs are first ingested under `sourcedata/` and then conversion is done using them, not straight from outside location (which must not be stored since could have sensitive data).  That would require work within `reproin` heuristic (and/or heudiconv) so it would know when to do DICOMs or niftis. ATM it does both (for scouts only dicoms)
- [ ] operate using included container(s).  ATM relies on heudiconv (and bids-validator) to be available in the environment, so I typically operate within maching singularity image... pain to switch between studies etc.
- [ ] `cron-convert` -- a job to be ran by cron, which would check new accessions in the past ?? hours, see if those studies were "vetted" (have some marker file e.g. `.heudiconv/reproin-cron-convert`) and convert them
- [ ] make it configurable, so it doesn't rely on hardcoded paths specific to our setup
- [ ] Basic documentation to describe setup

